### PR TITLE
Patch: Make test helpers available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   },
   "autoload": {
     "psr-4": {
-      "Photogabble\\Tuppence\\": "src"
+      "Photogabble\\Tuppence\\": "src",
+      "Photogabble\\Tuppence\\Tests\\Helpers\\": "tests/Helpers"
     }
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -675,25 +675,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -722,9 +722,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/http-server-handler",
@@ -895,30 +895,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -945,7 +945,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -961,7 +961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/App.php
+++ b/src/App.php
@@ -30,7 +30,7 @@ class App implements EventDispatcherAware
     /**
      * Tuppence Version.
      */
-    const VERSION = '2.0.2';
+    const VERSION = '2.0.3';
 
     use EventDispatcherAwareBehavior;
 

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -3,11 +3,11 @@
 namespace Photogabble\Tuppence\Tests\Feature;
 
 use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequestFactory;
 use League\Route\Http\Exception\NotFoundException;
 use Photogabble\Tuppence\ErrorHandlers\DefaultExceptionHandler;
+use Photogabble\Tuppence\Tests\Helpers\BootsApp;
 use Psr\Http\Message\ServerRequestInterface;
-use Photogabble\Tuppence\Tests\BootsApp;
-use Laminas\Diactoros\ServerRequestFactory;
 
 class RoutesTest extends BootsApp
 {

--- a/tests/Helpers/BootsApp.php
+++ b/tests/Helpers/BootsApp.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Photogabble\Tuppence\Tests;
+namespace Photogabble\Tuppence\Tests\Helpers;
 
 
-use Photogabble\Tuppence\App;
 use Laminas\Diactoros\ServerRequest;
+use Photogabble\Tuppence\App;
 use PHPUnit\Framework\TestCase;
 
 class BootsApp extends TestCase

--- a/tests/Helpers/MakesRequests.php
+++ b/tests/Helpers/MakesRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Photogabble\Tuppence\Tests;
+namespace Photogabble\Tuppence\Tests\Helpers;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Helpers/TestEmitter.php
+++ b/tests/Helpers/TestEmitter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Photogabble\Tuppence\Tests;
+namespace Photogabble\Tuppence\Tests\Helpers;
 
-use Psr\Http\Message\ResponseInterface;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class TestEmitter implements EmitterInterface
+final class TestEmitter implements EmitterInterface
 {
     private ResponseInterface $response;
 

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -3,6 +3,9 @@
 namespace Photogabble\Tuppence\Tests\Unit;
 
 use Exception;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use League\Container\Container;
 use League\Container\Exception\NotFoundException;
 use League\Event\EventDispatcher;
@@ -10,14 +13,11 @@ use League\Route\Router;
 use Photogabble\Tuppence\App;
 use Photogabble\Tuppence\ErrorHandlers\DefaultExceptionHandler;
 use Photogabble\Tuppence\ErrorHandlers\InvalidHandlerResponseException;
+use Photogabble\Tuppence\Tests\Helpers\TestEmitter;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Photogabble\Tuppence\Tests\TestEmitter;
-use Laminas\Diactoros\Response;
-use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
-use Laminas\Diactoros\ServerRequestFactory;
 
 class AppTest extends TestCase
 {


### PR DESCRIPTION
In trying to use the newly added `MakesRequests` trait I discovered that composers [autoload-dev](https://getcomposer.org/doc/04-schema.md#autoload-dev) is "root only" limiting the autoload only to the root package.